### PR TITLE
bvh first draft

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "three": "0.138.0",
+    "three-mesh-bvh": "^0.5.22",
     "zustand": "3.5.7"
   },
   "devDependencies": {

--- a/src/components/Buerligons.tsx
+++ b/src/components/Buerligons.tsx
@@ -11,6 +11,7 @@ import { Composer, Controls, Fit, Lights, Threshold, raycastFilter, GeometryInte
 import { FileMenu } from './FileMenu'
 import { UndoRedoKeyHandler } from './KeyHandler'
 import { WelcomePage } from './WelcomePage'
+import { Bvh } from './canvas/Bvh'
 
 const CanvasImpl: React.FC<{ drawingId: DrawingID }> = ({ children, drawingId }) => {
   const handleMiss = React.useCallback(() => {
@@ -35,7 +36,9 @@ const CanvasImpl: React.FC<{ drawingId: DrawingID }> = ({ children, drawingId })
       camera={{ position: [0, 0, 10], zoom: 50 }}
       onPointerMissed={handleMiss}>
       <HoveredConstraintDisplay drawingId={drawingId} />
-      <React.Suspense fallback={null}>{children}</React.Suspense>
+      <React.Suspense fallback={null}>
+        <Bvh drawingId={drawingId}>{children}</Bvh>
+      </React.Suspense>
     </Canvas>
   )
 }

--- a/src/components/canvas/Bvh.tsx
+++ b/src/components/canvas/Bvh.tsx
@@ -1,0 +1,81 @@
+import { DrawingID } from '@buerli.io/core'
+import { useDrawing } from '@buerli.io/react'
+import { useThree } from '@react-three/fiber'
+import * as React from 'react'
+import * as THREE from 'three'
+import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree } from 'three-mesh-bvh'
+
+export interface BVHOptions {
+  /** Split strategy, default: SAH (slowest to construct, fastest runtime, least memory) */
+  splitStrategy?: 'CENTER' | 'AVERAGE' | 'SAH'
+  /** Print out warnings encountered during tree construction, default: false */
+  verbose?: boolean
+  /** If true then the bounding box for the geometry is set once the BVH has been constructed, default: true */
+  setBoundingBox?: boolean
+  /** The maximum depth to allow the tree to build to, default: 40 */
+  maxDepth?: number
+  /** The number of triangles to aim for in a leaf node, default: 10 */
+  maxLeafTris?: number
+}
+
+export type BvhProps = BVHOptions &
+  JSX.IntrinsicElements['group'] & {
+    drawingId: DrawingID
+    /**Enabled, default: true */
+    enabled?: boolean
+    /** Use .raycastFirst to retrieve hits which is generally faster, default: false */
+    firstHitOnly?: boolean
+  }
+
+export function Bvh({
+  drawingId,
+  enabled = true,
+  firstHitOnly = false,
+  children,
+  splitStrategy = 'SAH',
+  verbose = false,
+  setBoundingBox = true,
+  maxDepth = 40,
+  maxLeafTris = 10,
+  ...props
+}: BvhProps) {
+  const ref = React.useRef<THREE.Group>(null!)
+  const raycaster = useThree(state => state.raycaster)
+
+  // Trigger when new geometries have been added
+  const ccBounds = useDrawing(drawingId, d => d.geometry.stamp)
+
+  React.useEffect(() => {
+    if (enabled) {
+      const options = { splitStrategy, verbose, setBoundingBox, maxDepth, maxLeafTris }
+      const group = ref.current
+      // This can only safely work if the component is used once, but there is no alternative.
+      // Hijacking the raycast method to do it for individual meshes is not an option as it would
+      // cost too much memory ...
+      ;(raycaster as any).firstHitOnly = firstHitOnly
+      group.traverse((child: any) => {
+        // Only include meshes that do not yet have a boundsTree and whose raycast is standard issue
+        if (child.isMesh && !child.geometry.boundsTree && child.raycast === THREE.Mesh.prototype.raycast) {
+          child.raycast = acceleratedRaycast
+          child.geometry.computeBoundsTree = computeBoundsTree
+          child.geometry.disposeBoundsTree = disposeBoundsTree
+          child.geometry.computeBoundsTree(options)
+        }
+      })
+      return () => {
+        delete (raycaster as any).firstHitOnly
+        group.traverse((child: any) => {
+          if (child.isMesh && child.geometry.boundsTree) {
+            child.geometry.disposeBoundsTree()
+            child.raycast = THREE.Mesh.prototype.raycast
+          }
+        })
+      }
+    }
+  })
+  return (
+    <group ref={ref} {...props}>
+      {children}
+    </group>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14056,6 +14056,11 @@ threads@^0.12.0:
     eventemitter3 "^2.0.2"
     native-promise-only "^0.8.1"
 
+three-mesh-bvh@^0.5.22:
+  version "0.5.22"
+  resolved "https://registry.yarnpkg.com/three-mesh-bvh/-/three-mesh-bvh-0.5.22.tgz#9c20fbaba1f55c7afe3fe769a90c4605e3bd53ee"
+  integrity sha512-vi9X78CoEz1VVfkKRpUZQa34SEc0QGDd9Hmyis0aeBRAmjp4BpHQ2URcirBsOvFMNBXqB9Klp8sQ9NCRsUEW0w==
+
 three-mesh-bvh@^0.5.7:
   version "0.5.14"
   resolved "https://registry.yarnpkg.com/three-mesh-bvh/-/three-mesh-bvh-0.5.14.tgz#605654cf802b3e92ea7b18997535960d04344159"


### PR DESCRIPTION
wraps all geometries into an bvh oct tree for faster raycast response.

atm it is unclear if it should be a separate component of part of fastgeometry. most likely fast geometry would be the better place as it can safely differentiate between buerli geometry and everything else.