### PR TITLE
CAD-4084 adapt terms and names (current instance)

### DIFF
--- a/src/components/Buerligons.tsx
+++ b/src/components/Buerligons.tsx
@@ -42,7 +42,7 @@ const CanvasImpl: React.FC<{ drawingId: DrawingID; children?: React.ReactNode }>
 }
 
 const useInteractionReset = (drawingId: DrawingID) => {
-  const currentNode = useDrawing(drawingId, d => d.structure.currentNode)
+  const currentInstance = useDrawing(drawingId, d => d.structure.currentInstance)
   const isSelActive = useDrawing(drawingId, d => d.selection.active !== null) || false
   const activeId = useDrawing(drawingId, d => d.plugin.refs[d.plugin.active.feature || -1]?.objectId)
   const objClass = useDrawing(drawingId, d => d.structure.tree[activeId || -1]?.class) || ''
@@ -64,13 +64,13 @@ const useInteractionReset = (drawingId: DrawingID) => {
   // Reset hover and selection when switching nodes
   React.useEffect(() => {
     resetInteraction()
-  }, [resetInteraction, currentNode])
+  }, [resetInteraction, currentInstance])
 }
 
 export const Buerligons: React.FC = () => {
   const count = useBuerli(s => s.drawing.ids.length)
   const drawingId = useBuerli(s => s.drawing.active || '')
-  const currentNode = useDrawing(drawingId, d => d.structure.currentNode) || undefined
+  const currentInstance = useDrawing(drawingId, d => d.structure.currentInstance) || undefined
   const currentProduct = useDrawing(drawingId, d => d.structure.currentProduct)
   const curProdClass = useDrawing(drawingId, d => currentProduct && d.structure.tree[currentProduct]?.class) || ''
   const isPart = ccUtils.base.isA(curProdClass, CCClasses.CCPart)
@@ -100,7 +100,7 @@ export const Buerligons: React.FC = () => {
               <Fit drawingId={drawingId}>
                 <Composer drawingId={drawingId} width={5}>
                   <GeometryInteraction drawingId={drawingId}>
-                    <BuerliGeometry suspend={['.Load']} drawingId={drawingId} productId={isPart ? currentProduct : currentNode} selection={false} />
+                    <BuerliGeometry suspend={['.Load']} drawingId={drawingId} productId={isPart ? currentProduct : currentInstance} selection={false} />
                   </GeometryInteraction>
                 </Composer>
                 <PluginGeometryBounds drawingId={drawingId} />

--- a/src/components/canvas/Gizmo/Gizmo.tsx
+++ b/src/components/canvas/Gizmo/Gizmo.tsx
@@ -32,13 +32,13 @@ export const Gizmo: React.FC<{ drawingId: DrawingID; productId: ObjectID; matrix
     ({ component }: { component: 'Arrow' | 'Slider' | 'Rotator' }) => {
       const drawing = getDrawing(drawingId)
       const curProdId = drawing.structure.currentProduct
-      const curNodeId = drawing.structure.currentNode
-      const draggedNodeId = findInteractableParent(drawingId, productId)
-      if (!curProdId || !curNodeId || !draggedNodeId || !productId) {
+      const curInstanceId = drawing.structure.currentInstance
+      const draggedInstanceId = findInteractableParent(drawingId, productId)
+      if (!curProdId || !curInstanceId || !draggedInstanceId || !productId) {
         return
       }
 
-      const mP = drawing.api.structure.calculateGlobalTransformation(curNodeId)
+      const mP = drawing.api.structure.calculateGlobalTransformation(curInstanceId)
       const mPInv = mP.clone().invert()
       const mL0C = drawing.api.structure.calculateGlobalTransformation(productId).premultiply(mPInv)
       const mL0CInv = mL0C.invert()
@@ -53,17 +53,17 @@ export const Gizmo: React.FC<{ drawingId: DrawingID; productId: ObjectID; matrix
       const selectedRefsUnique = selectedRefs.filter(
         (refId, id) => refId && id === selectedRefs.indexOf(refId),
       ) as ObjectID[]
-      const draggedNodes = selectedRefsUnique.map(
+      const draggedInstances = selectedRefsUnique.map(
         id => (drawing.structure.tree[id].members?.productRef?.value || id) as ObjectID,
       )
 
       dragInfo.current = { mPInv, mL0CInv }
-      ccAPI.assemblyBuilder.startMovingUnderConstraints(drawingId, curProdId, draggedNodes, pivotPos, mucType)
+      ccAPI.assemblyBuilder.startMovingUnderConstraints(drawingId, curProdId, draggedInstances, pivotPos, mucType)
     },
     [drawingId, productId, position],
   )
 
-  const transformNodes = React.useCallback(
+  const transformInstances = React.useCallback(
     async (mdL_: THREE.Matrix4) => {
       const curProdId = getDrawing(drawingId).structure.currentProduct || -1
 
@@ -83,7 +83,7 @@ export const Gizmo: React.FC<{ drawingId: DrawingID; productId: ObjectID; matrix
       promise = null
 
       if (mdL.current) {
-        transformNodes(mdL.current.clone())
+        transformInstances(mdL.current.clone())
         mdL.current = null
       }
     },
@@ -101,10 +101,10 @@ export const Gizmo: React.FC<{ drawingId: DrawingID; productId: ObjectID; matrix
       if (promise) {
         mdL.current = mdL_
       } else {
-        transformNodes(mdL_)
+        transformInstances(mdL_)
       }
     },
-    [transformNodes],
+    [transformInstances],
   )
 
   const onDragEnd = React.useCallback(() => {

--- a/src/components/canvas/Gizmo/utils.ts
+++ b/src/components/canvas/Gizmo/utils.ts
@@ -52,9 +52,9 @@ const getAdjacentMeshNormal = (
 
 export const findInteractableParent = (drawingId: DrawingID, refId: ObjectID) => {
   const drawing = getDrawing(drawingId)
-  const curNodeId = drawing.structure.currentNode || -1
-  const curNode = drawing.structure.tree[curNodeId]
-  const interactable = curNode?.children || []
+  const curInstId = drawing.structure.currentInstance || -1
+  const curInst = drawing.structure.tree[curInstId]
+  const interactable = curInst?.children || []
 
   const ancestors: ObjectID[] = []
   let objId: number | null = refId

--- a/src/components/canvas/Interaction/utils.ts
+++ b/src/components/canvas/Interaction/utils.ts
@@ -87,7 +87,7 @@ export const selectObject = (drawingId: DrawingID, productId: ObjectID, object: 
 
 // TODO: Rename this function
 export const convertSelToInteraction = (drawingId: DrawingID, selItems: SelectedItem[]) => {
-  const curNodeId = getDrawing(drawingId).structure.currentNode
+  const curInstanceId = getDrawing(drawingId).structure.currentInstance
   const curProdId = getDrawing(drawingId).structure.currentProduct as ObjectID
 
   const interactionInfoArr = selItems.map(item => {
@@ -105,7 +105,7 @@ export const convertSelToInteraction = (drawingId: DrawingID, selItems: Selected
         const object = item.data.object
         return createInfo({
           objectId: object.id,
-          prodRefId: curNodeId || curProdId,
+          prodRefId: curInstanceId || curProdId,
         })
       }
       case MateScope: {


### PR DESCRIPTION
This task is about renaming currentNode and related variables to currentInstance

Direct related PR's:
[buerli PR](https://github.com/awv-informatik/buerli/pull/545)
[buerli-react-cad PR](https://github.com/awv-informatik/buerli-react-cad/pull/563)
[Shelveset ](https://devops01.ost.ch/ClassCAD/CCBase/_versionControl/shelveset?ss=CAD-4084+Adapt+terms+and+names%3BDEVOPS01%5Crbruelisauer): CAD-4084 Adapt terms and names
[Shelveset ](https://devops01.ost.ch/ClassCAD/CCBase/_versionControl/shelveset?ss=CAD-4084+Add+currentInstance+to+structure+protocol%3BDEVOPS01%5Cdmanser): CAD-4084 Add currentInstance to structure protocol

Indirect related PR's:
[buerli-modeler PR](https://github.com/awv-informatik/buerli-modeler/pull/122)
[buerli-examples](https://github.com/awv-informatik/buerli-examples/pull/24)

This PR must not be merged until [main PR](https://github.com/awv-informatik/buerli/pull/531) of CAD-4084 and its related PR's are merged!