### PR TITLE
Gizmo behavior in subassemblies fix

### DIFF
--- a/src/components/canvas/Gizmo/utils.ts
+++ b/src/components/canvas/Gizmo/utils.ts
@@ -53,9 +53,9 @@ export const getAdjacentMeshNormal = (
 
 export const findInteractableParent = (drawingId: DrawingID, refId: ObjectID) => {
   const drawing = getDrawing(drawingId)
-  const curInstId = drawing.structure.currentInstance || -1
-  const curInst = drawing.structure.tree[curInstId]
-  const interactable = curInst?.children || []
+  const curProdId = drawing.structure.currentProduct || -1
+  const curProd = drawing.structure.tree[curProdId]
+  const interactable = curProd?.children || []
 
   return mateUtils.getProductRigidSet(drawingId, refId, interactable)
 }


### PR DESCRIPTION
This fixes the MUC functionality not working when structure.currentInstance is set to a subassembly instance
(This was caused by changes to mateUtils.getProductRigidSet)

buerli-react-cad PR: https://github.com/awv-informatik/buerli-react-cad/pull/635